### PR TITLE
added hasRoleOrPermission functionality

### DIFF
--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -179,6 +179,12 @@ class MenuItem implements MenuInterface, Arrayable, JsonSerializable
             }
         }
 
+        if (!empty($this->conditions['hasRoleOrPermission'])) {
+            if (! Auth::user()->hasAnyRole($this->conditions['hasRoleOrPermission']) && ! Auth::user()->hasAnyPermission($this->conditions['hasRoleOrPermission'])) {
+                return false;
+            }
+        }
+
         if ($this->visibility instanceof Closure) {
             return $this->visibility($this);
         }
@@ -264,6 +270,21 @@ class MenuItem implements MenuInterface, Arrayable, JsonSerializable
     public function hasAnyPermissions($permission, $guardName = null): MenuItem
     {
         $this->conditions['hasAnyPermissions'] = func_get_args();
+        return $this;
+    }
+
+    /**
+     * @param string|array $roleOrPermission
+     * @return $this
+     */
+    public function hasRoleOrPermission($roleOrPermission): MenuItem
+    {
+        $rolesOrPermissions = is_array($roleOrPermission)
+            ? $roleOrPermission
+            : explode('|', $roleOrPermission);
+
+        $this->conditions['hasRoleOrPermission'] = $rolesOrPermissions;
+
         return $this;
     }
 


### PR DESCRIPTION
The `hasRoleOrPermission` functionality has been added. This method allows to check whether the user has the necessary role or permission to see a particular menu item.